### PR TITLE
Force readFile

### DIFF
--- a/graphmod.cabal
+++ b/graphmod.cabal
@@ -19,7 +19,7 @@ executable graphmod
     main-is:         Main.hs
     other-modules:   Utils, Trie, Paths_graphmod, CabalSupport
     build-depends:   base < 5, directory, filepath, dotgen >= 0.2 && < 0.5,
-                     haskell-lexer >= 1.0.1, containers, Cabal
+                     haskell-lexer >= 1.0.1, containers, Cabal, deepseq
     hs-source-dirs:  src
     ghc-options:     -Wall -O2
 

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -15,6 +15,7 @@ module Utils
 
 import Language.Haskell.Lexer(lexerPass0,Token(..),PosToken,line)
 
+import Control.DeepSeq
 import Control.Monad(mplus)
 import Data.Maybe(catMaybes)
 import Data.List(intersperse,isPrefixOf)
@@ -30,7 +31,7 @@ data ImpType = NormalImp | SourceImp
 -- | Get the imports of a file.
 parseFile          :: FilePath -> IO (ModName,[Import])
 parseFile f =
-  do (modName, imps) <- (parseString . get_text) `fmap` readFile f
+  do (modName, imps) <- (parseString . get_text . force) `fmap` readFile f
      if ext == ".imports"
        then return (splitModName (takeBaseName f), imps)
        else return (modName, imps)


### PR DESCRIPTION
```
$ find src -name '*.hs' | stack exec -- xargs graphmod -q > modgraph.dot
graphmod: src/Pos/Update/Logic/Local.hs: openFile: resource exhausted (Too many open files)
```

This PR fixes it. `readFile` is too lazy, it doesn't free the file handles until you've consumed the whole string.