### PR TITLE
Support Cabal >= 2.0

### DIFF
--- a/graphmod.cabal
+++ b/graphmod.cabal
@@ -26,12 +26,10 @@ executable graphmod
     main-is:         Main.hs
     other-modules:   Utils, Trie, Paths_graphmod, CabalSupport
     build-depends:   base < 5, directory, filepath, dotgen >= 0.2 && < 0.5,
-                     haskell-lexer >= 1.0.1, containers, Cabal
+                     haskell-lexer >= 1.0.1, containers, Cabal, pretty
     hs-source-dirs:  src
     ghc-options:     -Wall -O2
 
 source-repository head
   type:     git
   location: git://github.com/yav/graphmod
-
-


### PR DESCRIPTION
This enables the package to be build on GHC-8.2. I tested the executable and the result was correct.