### PR TITLE
expose Utils.hs as library

### DIFF
--- a/graphmod.cabal
+++ b/graphmod.cabal
@@ -30,8 +30,8 @@ executable graphmod
   default-language: Haskell2010
 
 library
-    exposed-modules: Graphmod
-    other-modules:   Utils, Trie, Paths_graphmod, CabalSupport
+    exposed-modules: Graphmod, Utils
+    other-modules:   Trie, Paths_graphmod, CabalSupport
     build-depends:   base < 5, directory, filepath, dotgen >= 0.2 && < 0.5,
                      haskell-lexer >= 1.0.2, containers, Cabal, pretty
     hs-source-dirs:  src

--- a/graphmod.cabal
+++ b/graphmod.cabal
@@ -30,7 +30,7 @@ executable graphmod
   default-language: Haskell2010
 
 library
-    exposed-modules: Graphmod, Utils
+    exposed-modules: Graphmod, Graphmod.Utils
     other-modules:   Trie, Paths_graphmod, CabalSupport
     build-depends:   base < 5, directory, filepath, dotgen >= 0.2 && < 0.5,
                      haskell-lexer >= 1.0.2, containers, Cabal, pretty

--- a/src/CabalSupport.hs
+++ b/src/CabalSupport.hs
@@ -2,7 +2,7 @@
 
 module CabalSupport (parseCabalFile,Unit(..),UnitName(..)) where
 
-import Utils(ModName,fromHierarchy)
+import Graphmod.Utils(ModName,fromHierarchy)
 
 import Data.Maybe(maybeToList)
 import System.FilePath((</>))

--- a/src/Graphmod.hs
+++ b/src/Graphmod.hs
@@ -1,6 +1,6 @@
 module Graphmod (graphmod) where
 
-import Utils
+import Graphmod.Utils
 import qualified Trie
 import CabalSupport(parseCabalFile,Unit(..))
 import Text.Dot

--- a/src/Graphmod/Utils.hs
+++ b/src/Graphmod/Utils.hs
@@ -1,4 +1,4 @@
-module Utils
+module Graphmod.Utils
   ( parseFile
   , parseString
   , Qualifier

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -25,7 +25,7 @@ import qualified System.IO as IO
 import System.FilePath
 
 data Import = Import { impMod :: ModName, impType :: ImpType }
-                deriving Show
+                deriving (Show, Eq)
 
 data ImpType = NormalImp | SourceImp
                 deriving (Show,Eq,Ord)
@@ -134,7 +134,7 @@ imports ts          = case isImp $ dropWhile (not . (("import" ==) . snd . snd))
 -- We make this an opaque type with accessors 'qualifierNodes' and 'fromHierarchy' 
 -- so that we can transparently add new structure to this type.
 data Qualifier = Hierarchy [String]
-    | FromFile [String] deriving (Show)
+    | FromFile [String] deriving (Show, Eq)
 qualifierNodes :: Qualifier -> [String]
 qualifierNodes (Hierarchy qs) = qs
 qualifierNodes (FromFile qs) = qs


### PR DESCRIPTION
In a project of mine I wrote a dependency validation which builds upon your Utils.hs.
As Utils is not part of the exposed-modules declaration in graphmod.cabal I had to include a verbatim copy of Utils.hs to my code base.

With this pull request Util is made part of the exposed-modules declaration.
This will allow to also access Utils.hs when adding graphmod as a library dependency.

In a second commit I made Qualifier and Import instances of Eq by changing their deriving clauses.
This will allow testing for equally in user code. 

thanks for your very useful tool!