### PR TITLE
Add option to not try to disambiguate multiple main modules

### DIFF
--- a/src/Graphmod.hs
+++ b/src/Graphmod.hs
@@ -108,11 +108,11 @@ graph opts inputs = fmap maybePrune $ mfix $ \ ~(_,mods) ->
                               then add done es size m [] todo
                               else loop done es size todo
                f : gs -> do unless (null gs) (warn opts (ambigMsg m fs))
-                            (x,imps) <- parseFile f
+                            (x,imps) <- parseFile (multi_main opts) f
                             add done es size x imps todo
 
       loop done es size (File f : todo) =
-        do (m,is) <- parseFile f
+        do (m,is) <- parseFile (multi_main opts) f
            if ignore done m
              then loop done es size todo
              else add done es size m is todo
@@ -489,6 +489,7 @@ data Opts = Opts
   , graph_size    :: String
 
   , use_cabal     :: Bool -- ^ should we try to use a cabal file, if any
+  , multi_main    :: Bool
   }
 
 type IgnoreSet  = Trie.Trie String IgnoreSpec
@@ -510,6 +511,7 @@ default_opts = Opts
   , prune_edges     = False
   , graph_size      = "6,4"
   , use_cabal       = True
+  , multi_main      = True
   }
 
 options :: [OptDescr OptT]
@@ -555,6 +557,9 @@ options =
 
   , Option ['v'] ["version"]   (NoArg set_show_version)
     "Show the current version."
+  
+  , Option [] ["single-main"] (NoArg set_single_main)
+    "Don't try to disambiguate multiple main modules"
   ]
 
 add_current      :: OptT
@@ -576,6 +581,9 @@ set_no_cluster o  = o { use_clusters = False }
 
 set_no_mod_in_cluster :: OptT
 set_no_mod_in_cluster o = o { mod_in_cluster = False }
+
+set_single_main :: OptT
+set_single_main o = o { multi_main = False }
 
 add_inc          :: FilePath -> OptT
 add_inc d o       = o { inc_dirs = d : inc_dirs o }

--- a/src/Graphmod/Utils.hs
+++ b/src/Graphmod/Utils.hs
@@ -31,8 +31,8 @@ data ImpType = NormalImp | SourceImp
                 deriving (Show,Eq,Ord)
 
 -- | Get the imports of a file.
-parseFile          :: FilePath -> IO (ModName,[Import])
-parseFile f =
+parseFile          :: Bool -> FilePath -> IO (ModName,[Import])
+parseFile multi_main f =
   do h <- IO.openFile f IO.ReadMode
      IO.hSetEncoding h IO.utf8
      (modName, imps) <- (parseString . get_text) `fmap` IO.hGetContents h
@@ -42,7 +42,7 @@ parseFile f =
        then return (splitModName (takeBaseName f), imps)
        else case modName of
             -- disambiguate Main modules with no qualifiers
-            (Hierarchy [],"Main") -> return (splitFilePath f,imps)
+            (Hierarchy [],"Main") | multi_main -> return (splitFilePath f,imps)
             _ -> return (modName, imps)
 
 


### PR DESCRIPTION
This adds a flag to not try to disambiguate multiple `Main` modules.